### PR TITLE
Remove refreshToken field from user document

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -165,7 +165,7 @@ const logoutUser = asyncHandler(async (req, res) => {
         req.user._id,
         {
             $set: {
-                refreshToken: undefined
+                refreshToken: 1 // this will remove the field from the document
             }
         },
         {
@@ -252,7 +252,7 @@ const changeCurrentPassword = asyncHandler(async (req, res) => {
 const getCurrentUser = asyncHandler(async (req, res) => {
     return res
         .status(200)
-        .json(200, req.user, "Current user fetched successfully")
+        .json(new ApiResponse(200, req.user, "Current user fetched successfully"))
 })
 
 const updateAccountDetails = asyncHandler(async (req, res) => {
@@ -345,7 +345,7 @@ const getUserChannelProfile = asyncHandler(async (req, res) => {
         throw new ApiError(400, "Username is required")
     }
 
-    const channel = User.aggregate(
+    const channel = await User.aggregate(
         [
             {
                 $match: {


### PR DESCRIPTION
The code changes in the `user.controller.js` file remove the `refreshToken` field from the user document by setting it to `undefined`. This change improves security by removing the possibility of using an expired refresh token for authentication.